### PR TITLE
fix the error that the "filename" argument does not exist.

### DIFF
--- a/src/Commands/GenerateCommand.php
+++ b/src/Commands/GenerateCommand.php
@@ -24,7 +24,7 @@ class GenerateCommand extends Command
     /**
      * @var string
      */
-    protected $signature = 'ide-helper:redis {filename?=_ide_helper_redis.php : The path to the helper file}';
+    protected $signature = 'ide-helper:redis {filename=_ide_helper_redis.php : The path to the helper file}';
 
     /**
      * @var string


### PR DESCRIPTION
报错异常信息：

`The "filename" argument does not exist.`